### PR TITLE
Replace BusyBox sort with gnusort in the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@
 ###############################################
 FROM ghcr.io/astral-sh/uv:python3.13-alpine
 
-RUN apk update & apk add build-base zlib-dev
+RUN apk add --update --no-cache build-base zlib-dev coreutil
+
 # Copy the project into the image
 ADD . /app
 

--- a/genmod/vcf_tools/sort_variants.py
+++ b/genmod/vcf_tools/sort_variants.py
@@ -27,7 +27,6 @@ def sort_variants(infile, mode="chromosome"):
     Args:
         infile : A string that is the path to a file
         mode : 'chromosome' or 'rank'
-        outfile : The path to an outfile where the variants should be printed
 
     Returns:
         0 if sorting was performed
@@ -52,13 +51,17 @@ def sort_variants(infile, mode="chromosome"):
     sort_start = datetime.now()
 
     try:
-        call(command)
+        exit_code = call(command)
     except OSError as e:
         logger.warning("unix program 'sort' does not seem to exist on your system...")
         logger.warning("genmod needs unix sort to provide a sorted output.")
         logger.warning("Output VCF will not be sorted since genmod can not findunix sort")
         raise e
 
+    if exit_code:
+        logger.warning("Output VCF will not be sorted since unix sort exited with code {0}".format(exit_code))
+        raise ValueError("unix sort exited with code {0}".format(exit_code))
+
     logger.info("Sorting done. Time to sort: {0}".format(datetime.now() - sort_start))
 
-    return
+    return exit_code


### PR DESCRIPTION
## Description

### Changed

- Improved the function sort_variants to check unix sort exit code for better error handling.
- Added the coreutils package in the container, which includes gnusort with full support for "Version sort".

### Fixed

-


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_[TOOL]-t [TOOL] -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
